### PR TITLE
Fix typo in property name

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -83,7 +83,7 @@ function Local(cli, files) {
   this.browserify_transforms = cli.browserify_options.transform || []
   this.browserify_deps = cli.browserify_options.entry || []
   this.browserify_requires = cli.browserify_options.require || []
-  this.browserify_externals = cli.browserify_options.exteral || []
+  this.browserify_externals = cli.browserify_options.external || []
   this.files = files
 
 }


### PR DESCRIPTION
Somehow missed this. Without this fix externals explicitly passed to browserify via `--external` or `-x` will be ignored.
