### PR TITLE
Put config object in a more logical place

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -392,8 +392,13 @@ proto.env_suite = function(req, resp, env_uuid, run_uuid) {
     , client = run.request.client.dnode || run.request.client
     , suite = run.current() || bail('no such suite')
     , is_browserify = client.browserify
+    , is_failfast = client.failfast
     , wants_json = run.wants_json()
+    , config
 
+  config = '\nwindow.__config__ = {}\n' +
+      'window.__config__.failfast = ' + is_failfast + '\n' +
+      'window.__config__.browserify = ' + is_browserify + '\n'
   // what are we sending down?
   // well. we need to send an entire new page with the proper dom
   // (or if the enviroment wants json, the html as part of a bigger JSON blob.)
@@ -402,6 +407,8 @@ proto.env_suite = function(req, resp, env_uuid, run_uuid) {
 
   function then_load(err, bundled_js) {
     bundled_js = err ? '' : bundled_js
+    bundled_js += config
+
     run.request.client.load(run.current().name, function(err, data) {
       suite.load_from(data)
 

--- a/lib/suite.js
+++ b/lib/suite.js
@@ -81,15 +81,11 @@ proto.respond_media = function(req, resp, endpoint, env, run) {
     , mimetype = mime(endpoint)
     , is_test
     , client
-    , config
     , is_js
 
   client = self.request.client.dnode || self.request.client
   is_js = mimetype.indexOf('javascript') > -1
   is_test = /\.test\.js$/.test(endpoint)
-  config = '\nwindow.__config__ = {}\n' +
-      'window.__config__.failfast = ' + !!client.failfast + '\n' +
-      'window.__config__.browserify = ' + !!client.browserify + '\n'
 
   if(client.browserify && is_js && is_test) {
     return media_loaded(
@@ -104,10 +100,6 @@ proto.respond_media = function(req, resp, endpoint, env, run) {
     if(err) {
       resp.writeHead(404, {'Content-Type':'text/plain'})
       return resp.end('wat')
-    }
-
-    if(is_test) {
-      data += config
     }
 
     if(is_js) {


### PR DESCRIPTION
So, this should have been done this way in the first place.

Since the previous change was made I **have** encountered it malfunctioning (though only once) that's not good.

This will make sure the config object is available before it is ever referenced, verified.
