### PR TITLE
defer browserify opt-parsing to browserify

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,13 +20,18 @@ var Client = require('./client').LocalClient
 
 function CLI(argv, streams) {
   streams = streams || {}
-  this.options = nopt(this.noptions, this.nopt_shorthands, argv)
-  this.browserify_options = nopt(
-      this.browserify_noptions
-    , this.browserify_shorthands
-    , this.options.argv.remain
-    , 0
+
+  var bfy_idx = argv.indexOf('--')
+
+  bfy_idx = bfy_idx === -1 ? argv.length : bfy_idx
+
+  this.options = nopt(
+      this.noptions
+    , this.nopt_shorthands
+    , argv.slice(0, bfy_idx)
   )
+
+  this.browserify_options = argv.slice(bfy_idx + 1)
   this.stderr = streams.stderr || process.stderr
   this.stdout = streams.stdout || process.stdout
 }
@@ -50,21 +55,6 @@ proto.noptions = {
 
 proto.nopt_shorthands = {
     'x': ['--failfast']
-}
-
-proto.browserify_noptions = {
-    'transform': Array
-  , 'noparse': Array
-  , 'external': Array
-  , 'entry': Array
-  , 'require': Array
-}
-
-proto.browserify_shorthands = {
-    't': ['--transform']
-  , 'e': ['--entry']
-  , 'r': ['--require']
-  , 'x': ['--external']
 }
 
 proto.exit = function(num) {
@@ -167,7 +157,7 @@ proto.exec = function() {
 }
 
 proto.get_tests = function() {
-  var remain = this.browserify_options.argv.remain
+  var remain = this.options.argv.remain
 
   if(remain.length) {
     return this.validate_files(remain)
@@ -254,7 +244,7 @@ proto.spawn = function(port) {
 }
 
 proto.client = function(driver_url) {
-  if(!this.browserify_options.argv.remain.length) {
+  if(!this.options.argv.remain.length) {
     return console.log('must provide a list of files to test')
   }
 
@@ -270,7 +260,7 @@ proto.client = function(driver_url) {
       this
     , rest
     , this.options.browserify
-    , this.browserify_options || {}
+    , this.browserify_options || [] 
     , this.options.failfast
   )
 
@@ -288,7 +278,7 @@ proto.client = function(driver_url) {
 }
 
 proto.local = function() {
-  if(!this.browserify_options.argv.remain.length) {
+  if(!this.options.argv.remain.length) {
     return console.log('must provide a list of files to test')
   }
 
@@ -318,7 +308,7 @@ proto.local = function() {
 
       client = new Client(
           self
-        , self.browserify_options.argv.remain
+        , self.options.argv.remain
         , self.options.browserify
         , self.browserify_options || {}
         , self.options.failfast

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,11 +1,11 @@
 // (c) 2012 Urban Airship and Contributors
 module.exports = Client
 
-var browserify = require('browserify')
-  , fs = require('fs')
+var browserify = require('browserify/bin/args.js')
+  , tracejs = require('tracejs').trace
   , path = require('path')
   , util = require('util')
-  , tracejs = require('tracejs').trace
+  , fs = require('fs')
 
 var DIR = path.resolve(path.join(__dirname, '..'))
   , test_tr = require('./test_transform')
@@ -13,11 +13,7 @@ var DIR = path.resolve(path.join(__dirname, '..'))
 
 function Client(dnode, conn, for_browserify, browserify_options, failfast) {
   this.browserify = !!for_browserify
-  this.browserify_transforms = browserify_options.transform
-  this.browserify_noparse = browserify_options.noparse
-  this.browserify_deps = browserify_options.entry
-  this.browserify_requires = browserify_options.require
-  this.browserify_externals = browserify_options.external
+  this.browserify_options = browserify_options
   this.failfast = failfast
   this.dnode = dnode
   conn.on('end', this.disconnect_all.bind(this))
@@ -27,7 +23,6 @@ var cons = Client
   , proto = cons.prototype
 
 // server side
-
 proto.send = function(message) {
 
 }
@@ -80,11 +75,7 @@ function Local(cli, files) {
   this.num_errors = 0
   this.cli = cli
   this.browserify = !!cli.options.browserify
-  this.browserify_noparse = cli.browserify_options.noparse || []
-  this.browserify_transforms = cli.browserify_options.transform || []
-  this.browserify_deps = cli.browserify_options.entry || []
-  this.browserify_requires = cli.browserify_options.require || []
-  this.browserify_externals = cli.browserify_options.external || []
+  this.browserify_options = cli.browserify_options || []
   this.current_suite = null
   this.failfast = cli.options.failfast
   this.files = files
@@ -132,44 +123,26 @@ proto.load = function(name, ready) {
 
 proto.bundle_browserify = function(tests, ready) {
   var self = this
-    , transforms = self.browserify_transforms
-    , externals = self.browserify_externals
-    , noparse = self.browserify_noparse
-    , reqs = self.browserify_requires
-    , deps = self.browserify_deps
     , browserify_options = {}
     , bundler_options = {}
     , CWD = process.cwd()
     , test_bundles = {}
+    , bundler
+    , argv
 
-  bundler_options.insertGlobals = true
-  bundler_options.debug = true
+  argv = self.browserify_options.slice()
 
-  if(deps.length) {
-    browserify_options.entries = deps.map(resolve_file)
-  }
+  // inject a transform, insert globals by
+  // default, debug by default
+  argv = argv.concat([
+      '-t'
+    , path.join(__dirname, 'test_transform.js')
+    , '-ig'
+    , '-d'
+  ])
 
-  if(noparse.length) {
-    browserify_options.noParse = noparse.map(resolve_file)
-  }
-
-  var bundler = browserify(browserify_options)
-
-  externals.forEach(function(file) {
-    bundler.external(resolve_file(file))
-  })
-  transforms.forEach(function(file) {
-    file = resolve_file(file)
-
-    bundler.transform(require(file))
-  })
-  bundler.transform(test_tr)
-
-  reqs.forEach(function(file) {
-    bundler.require(file)
-  })
+  bundler = browserify(argv)
   tests.forEach(bundle_tests)
-
   bundler.bundle(bundler_options, onbundled)
 
   function bundle_tests(file) {
@@ -353,11 +326,7 @@ proto.dnodify = function() {
   var out = {}
 
   out.browserify = this.browserify
-  out.browserify_noparse = this.browserify_noparse
-  out.browserify_transforms = this.browserify_transforms
-  out.browserify_deps = this.browserify_deps
-  out.browserify_requires = this.browserify_requires
-  out.browserify_externals = this.browserify_externals
+  out.browserify_options = this.browserify_options || []
   out.failfast = this.failfast
   for(var key in this.constructor.prototype) if(this.constructor.prototype.hasOwnProperty(key))
     out[key] = this[key].bind(this)


### PR DESCRIPTION
instead of whitelisting args, this enables us to forward the raw arguments to browserify so it can parse them at its leisure.
