### PR TITLE
Fix a problem with slowness by reducing speed

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -34,6 +34,8 @@ function CLI(argv, streams) {
   this.browserify_options = argv.slice(bfy_idx + 1)
   this.stderr = streams.stderr || process.stderr
   this.stdout = streams.stdout || process.stdout
+
+  this.env = null
 }
 
 var cons = CLI
@@ -59,6 +61,10 @@ proto.nopt_shorthands = {
 
 proto.exit = function(num) {
   var self = this
+
+  if(self.env) {
+    self.env.exit()
+  }
 
   if(self.cached_writes)
     self.cached_writes.map(function(line) {
@@ -298,6 +304,7 @@ proto.local = function() {
 
     var env = new Env('http://localhost:' + port)
 
+    self.env = env
     env.connect()
 
     function got_env() {
@@ -312,6 +319,7 @@ proto.local = function() {
         , self.options.browserify
         , self.browserify_options || {}
         , self.options.failfast
+        , env
       )
 
       trr = new Request({}, client, rest, want)
@@ -319,7 +327,7 @@ proto.local = function() {
       if(!rest || !rest.length) {
         console.log('no valid tests, exiting...')
 
-        return process.exit(1)
+        return self.exit(1)
       }
 
       driver.request_test_run(trr)

--- a/lib/node_env.js
+++ b/lib/node_env.js
@@ -2,59 +2,42 @@
 
 module.exports = NodeEnvironment
 
-var mock_location = require('./node_location')
-  , mock_xhr  = require('./node_xhr')
-  , request   = require('request')
-  , jsdom     = require('jsdom')
+var fork = require('child_process').fork
+  , url = require('url')
 
 function NodeEnvironment(host, coverage_path) {
   this.host = host
   this.coverage_path = coverage_path || null
-
-  this.window =
-  this.document = null
+  this.child = null
 }
 
 var cons = NodeEnvironment
   , proto = cons.prototype
 
-proto.connect = function() {
-  process.on('uncaughtException', this.on_uncaught_exception.bind(this))
-  this.get_url('/')
+proto.connect = function(path) {
+  var child = fork(__dirname + '/node_subprocess.js')
+    , self = this
+
+  child.on('message', function(msg) {
+    if(msg.kill) {
+      child.send({url: null})
+
+      return self.connect(msg.url)
+    }
+
+    child.send({
+        url: url.resolve(self.host, msg.url)
+    })
+  })
+
+  child.send({url: url.resolve(this.host, path || '/')})
+
+  self.child = child
 }
 
-
-proto.get_url = function(path) {
-  var url = this.host + path
-
-  return request(url, this.got_url.bind(this, url))
-}
-
-proto.got_url = function(url, err, response, body) {
-  var options = {
-      features: {
-          FetchExternalResources: ['script']
-        , ProcessExternalResources: ['script']
-      }
-    , url: url
-  }
-
-  this.document = jsdom.jsdom(body, null, options)
-  this.window = this.document.parentWindow
-  this.window.console = console
-  this.window.console.__node__ = true
-  this.window.XMLHttpRequest = mock_xhr(this)
-  this.window.location = mock_location(this)
-
-  var self = this
-
-  this.window.on_location_change = function(location) {
-    return self.get_url(location.pathname)
-  }
-}
-
-proto.on_uncaught_exception = function(err) {
-  if(this.window && this.window.onerror) {
-    this.window.onerror(err)
+proto.exit = function() {
+  if(this.child) {
+    this.child.send({url: null})
+    this.child = null
   }
 }

--- a/lib/node_location.js
+++ b/lib/node_location.js
@@ -4,6 +4,16 @@ var jsdom = require('jsdom')
 var Location = require('jsdom/lib/jsdom/browser/location')
   , URL = require('url')
 
+module.exports = NodeLocation
+
+function NodeLocation(window) {
+  if(!(this instanceof NodeLocation)) {
+    return new NodeLocation(window)
+  }
+
+  Location.call(this, window.location.toString(), window)
+}
+
 NodeLocation.prototype = Object.create(Location.prototype, {
     href: {
         configurable: false
@@ -11,16 +21,6 @@ NodeLocation.prototype = Object.create(Location.prototype, {
       , set: set
     }
 })
-
-module.exports = NodeLocation
-
-function NodeLocation(env) {
-  if(!(this instanceof NodeLocation)) {
-    return new NodeLocation(env)
-  }
-
-  Location.call(this, env.window.location.toString(), env.window)
-}
 
 function get() {
   return this.toString()

--- a/lib/node_subprocess.js
+++ b/lib/node_subprocess.js
@@ -1,0 +1,62 @@
+process.on('message', onmessage)
+
+var mock_location = require('./node_location')
+  , spawn = require('child_process').spawn
+  , mock_xhr = require('./node_xhr')
+  , request = require('request')
+  , jsdom = require('jsdom')
+
+var runs_remaining = 64
+  , listener
+
+function onmessage(msg) {
+  if(!msg.url) {
+    return process.exit(0)
+  }
+
+  request(msg.url, ondata)
+
+  function ondata(err, response, body) {
+    var features = {
+        FetchExternalResources: ['script']
+      , ProcessExternalResources: ['script']
+    }
+
+    var options = {
+        features: features
+      , url: msg.url
+    }
+
+    var document
+      , window
+
+    if(listener) {
+      process.removeListener('uncaughtException', listener)
+    }
+
+    process.once('uncaughtException', listener = function(err) {
+      runs_remaining = 1
+      listener = null
+
+      if(!window.onerror) {
+        console.error(err.stack || err)
+
+        return
+      }
+
+      window.onerror(err)
+    })
+
+    document = jsdom.jsdom(body, null, options)
+    window = document.parentWindow
+    window.console = console
+    window.console.__node__ = true
+    window.location = mock_location(window)
+    window.XMLHttpRequest = mock_xhr(window)
+    window.on_location_change = function(location) {
+      --runs_remaining
+
+      return process.send({url: location.pathname, kill: !runs_remaining})
+    }
+  }
+}

--- a/lib/node_xhr.js
+++ b/lib/node_xhr.js
@@ -5,18 +5,18 @@ module.exports = create_xhr
 var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest
   , path = require('path')
 
-function create_xhr(env) {
+function create_xhr(window) {
   return StubbedXHR
 
   function StubbedXHR() {
     var xhr = new XMLHttpRequest
       , open = xhr.open
-      , host = 'http://' + env.window.location.host
+      , host = 'http://' + window.location.host
 
     xhr.open = function(method, url, async, user, password) {
       url = /^http(s)?:\/\//.test(url) ? url : 
             /^\//.test(url) ? host + url : 
-            host + path.join(env.window.location.pathname, url)
+            host + path.join(window.location.pathname, url)
 
       var result = open.call(this, method, url, async, user, password)
       this.setRequestHeader('User-Agent', 'node')


### PR DESCRIPTION
Somewhat less facetiously: 

There was a problem with jsdom retaining references to old code & not being able to GC it completely. Eventually tests would run OOM/start hitting swap, which is bad! This prevents that by spawning a process for each suite; which itself slows down everything, but at a constant rate.
