### PR TITLE
Add window.onclick = null to better match real browsers

### DIFF
--- a/lib/node_subprocess.js
+++ b/lib/node_subprocess.js
@@ -8,6 +8,25 @@ var mock_location = require('./node_location')
 
 var runs_remaining = 64
   , listener
+  , event_names = [
+        'onblur'
+      , 'onchange'
+      , 'onclick'
+      , 'ondblclick'
+      , 'onfocus'
+      , 'onkeydown'
+      , 'onkeypress'
+      , 'onkeyup'
+      , 'onmousedown'
+      , 'onmouseenter'
+      , 'onmouseleave'
+      , 'onmouseout'
+      , 'onmouseover'
+      , 'onmouseup'
+      , 'onresize'
+      , 'onselect'
+      , 'onsubmit'
+    ]
 
 function onmessage(msg) {
   if(!msg.url) {
@@ -53,7 +72,11 @@ function onmessage(msg) {
     window.console.__node__ = true
     window.location = mock_location(window)
     window.XMLHttpRequest = mock_xhr(window)
-    window.onclick = null
+
+    event_names.forEach(function(event_name) {
+      window[event_name] = null
+    })
+
     window.on_location_change = function(location) {
       --runs_remaining
 


### PR DESCRIPTION
While investigating some test failures, it appears that JSDOM does not provide the `onclick` property of `window`. Most browsers have this property, with a value of `null`. This PR allows drive.js to better match browsers for running tests. Will issue a PR to fix in JSDOM as well. (Who knows if they will accept.)
